### PR TITLE
Fix for icon-material.html - Wrong hint for usage

### DIFF
--- a/pages/icon-material.html
+++ b/pages/icon-material.html
@@ -461,7 +461,7 @@
                             <div class="card">
                                 <div class="card-header">
                                     <h4 class="card-title">Material Icons</h4>
-                                    <h6 class="card-subtitle">you can use any icon with class of <code class="m-r-10">mid mid-</code>name of icon</h6>
+                                    <h6 class="card-subtitle">you can use any icon with class of <code class="m-r-10">mdi mdi-</code>name of icon</h6>
                                 </div>
                                 <div class="card-body">
                                     <div class="material-icon-list-demo">


### PR DESCRIPTION
Changed the class names from `mid` to `mdi` in usage phrase as pointed out in  #4 

> you can use any icon with class of mid mid-name of icon
to
> you can use any icon with class of mdi mdi-name of icon